### PR TITLE
Add order storage to orders API, as well as GET order API endpoints

### DIFF
--- a/src/main/kotlin/com/testott/fruitstand/controller/OrderController.kt
+++ b/src/main/kotlin/com/testott/fruitstand/controller/OrderController.kt
@@ -1,5 +1,6 @@
 package com.testott.fruitstand.controller
 
+import com.testott.fruitstand.model.Order
 import com.testott.fruitstand.service.Invoice
 import com.testott.fruitstand.service.OrderService
 import com.testott.fruitstand.validation.ValidCart
@@ -8,10 +9,7 @@ import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 data class OrderRequest(
     @field:NotEmpty(message = "Cart must not be empty")
@@ -34,8 +32,28 @@ class OrderController(private val orderService: OrderService) {
 
     @PostMapping
     fun createOrder(@RequestBody @Valid orderRequest: OrderRequest): ResponseEntity<Invoice> {
-        val invoice = orderService.generateInvoice(orderRequest.cart)
+        val order = orderService.createOrder(orderRequest.cart)
+        return ResponseEntity.ok(order.invoice)
+    }
 
-        return ResponseEntity.ok(invoice)
+    @GetMapping("/{id}")
+    fun getOrderById(@PathVariable id: String): ResponseEntity<Order> {
+        val orderId = id.toLongOrNull()
+        return if (orderId != null) {
+            val order = orderService.getOrderById(orderId)
+            if (order != null) {
+                ResponseEntity.ok(order)
+            } else {
+                ResponseEntity.notFound().build()
+            }
+        } else {
+            ResponseEntity.badRequest().build()
+        }
+    }
+
+    @GetMapping
+    fun getAllOrders(): ResponseEntity<List<Order>> {
+        val orders = orderService.getAllOrders()
+        return ResponseEntity.ok(orders)
     }
 }

--- a/src/main/kotlin/com/testott/fruitstand/model/InvoiceConverter.kt
+++ b/src/main/kotlin/com/testott/fruitstand/model/InvoiceConverter.kt
@@ -1,0 +1,19 @@
+package com.testott.fruitstand.model
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.testott.fruitstand.service.Invoice
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+
+@Converter
+class InvoiceConverter : AttributeConverter<Invoice, String> {
+    private val objectMapper = ObjectMapper()
+
+    override fun convertToDatabaseColumn(attribute: Invoice): String {
+        return objectMapper.writeValueAsString(attribute)
+    }
+
+    override fun convertToEntityAttribute(dbData: String): Invoice {
+        return objectMapper.readValue(dbData, Invoice::class.java)
+    }
+}

--- a/src/main/kotlin/com/testott/fruitstand/model/Order.kt
+++ b/src/main/kotlin/com/testott/fruitstand/model/Order.kt
@@ -1,0 +1,26 @@
+package com.testott.fruitstand.model
+
+import com.testott.fruitstand.service.Invoice
+import jakarta.persistence.*
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@Entity
+data class Order(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    val orderDate: LocalDateTime = LocalDateTime.now(),
+
+    val totalAmount: BigDecimal,
+
+    @Lob
+    @Column(name = "invoice", columnDefinition = "TEXT")
+    @Convert(converter = InvoiceConverter::class)
+    val invoice: Invoice
+)
+
+@Repository
+interface OrderRepository : JpaRepository<Order, Long>

--- a/src/main/kotlin/com/testott/fruitstand/service/OrderService.kt
+++ b/src/main/kotlin/com/testott/fruitstand/service/OrderService.kt
@@ -2,8 +2,11 @@ package com.testott.fruitstand.service
 
 import com.testott.fruitstand.controller.CartItem
 import com.testott.fruitstand.model.FruitRepository
+import com.testott.fruitstand.model.Order
+import com.testott.fruitstand.model.OrderRepository
 import java.math.BigDecimal
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 data class LineItem(
     val name: String,
@@ -11,21 +14,57 @@ data class LineItem(
     val itemCost: String,
     val discount: String,
     val lineCost: String
-)
+) {
+    // No-argument constructor for Jackson
+    constructor() : this("", 0, "", "", "")
+}
 
 data class Invoice(
+    val orderId: Long,
     val lineItems: List<LineItem>,
     val totalDiscount: String,
     val totalCost: String
-)
+) {
+    // No-argument constructor for Jackson
+    constructor() : this(0, emptyList(), "", "")
+}
 
 @Service
 class OrderService(
     private val fruitRepository: FruitRepository,
-    private val discountService: DiscountService
+    private val discountService: DiscountService,
+    private val orderRepository: OrderRepository
 ) {
 
-    fun generateInvoice(cartItems: List<CartItem>): Invoice {
+    @Transactional
+    fun createOrder(cartItems: List<CartItem>): Order {
+        // Initial order object to get the generated id
+        val order = Order(
+            totalAmount = BigDecimal.ZERO,
+            invoice = Invoice()
+        )
+        val savedOrder = orderRepository.save(order)
+
+        val invoice = generateInvoice(cartItems, savedOrder.id)
+        val totalAmount = BigDecimal(invoice.totalCost)
+
+        val updatedOrder = savedOrder.copy(
+            totalAmount = totalAmount,
+            invoice = invoice
+        )
+
+        return orderRepository.save(updatedOrder)
+    }
+
+    fun getOrderById(id: Long): Order? {
+        return orderRepository.findById(id).orElse(null)
+    }
+
+    fun getAllOrders(): List<Order> {
+        return orderRepository.findAll()
+    }
+
+    fun generateInvoice(cartItems: List<CartItem>, orderId: Long): Invoice {
         val lineItems = mutableListOf<LineItem>()
         var totalCost = BigDecimal.ZERO
         var totalDiscount = BigDecimal.ZERO
@@ -58,6 +97,7 @@ class OrderService(
         }
 
         return Invoice(
+            orderId = orderId,
             lineItems = lineItems,
             totalDiscount = totalDiscount.negate().toPlainString(),
             totalCost = totalCost.toPlainString()

--- a/src/test/kotlin/com/testott/fruitstand/controller/OrderControllerTest.kt
+++ b/src/test/kotlin/com/testott/fruitstand/controller/OrderControllerTest.kt
@@ -1,11 +1,13 @@
 package com.testott.fruitstand.controller
 
-import com.testott.fruitstand.service.OrderService
-import com.testott.fruitstand.model.FruitRepository
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
 import com.testott.fruitstand.model.Fruit
+import com.testott.fruitstand.model.FruitRepository
+import com.testott.fruitstand.model.Order
 import com.testott.fruitstand.service.Invoice
 import com.testott.fruitstand.service.LineItem
-import com.ninjasquad.springmockk.MockkBean
+import com.testott.fruitstand.service.OrderService
 import io.mockk.every
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -13,9 +15,12 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import java.math.BigDecimal
+import java.time.LocalDateTime
 
 @WebMvcTest(OrderController::class)
 class OrderControllerTest {
@@ -40,7 +45,7 @@ class OrderControllerTest {
     @Test
     fun `createOrder should return 400 when given empty cart`() {
         // Arrange
-        val invalidPayload = """
+        val emptyCartPayload = """
             {
                 "cart": []
             }
@@ -50,20 +55,18 @@ class OrderControllerTest {
         mockMvc.perform(
             post("/api/orders")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(invalidPayload)
+                .content(emptyCartPayload)
         ).andExpect(status().isBadRequest)
     }
 
     @Test
     fun `createOrder should return 400 when given invalid cart line items`() {
         // Arrange
-        val invalidPayload = """
+        val invalidCartPayload = """
             {
                 "cart": [
-                    {
-                        "name": "",
-                        "quantity": 0
-                    }
+                    {"name": "apple", "quantity": -1},
+                    {"name": "orange", "quantity": 0}
                 ]
             }
         """.trimIndent()
@@ -72,20 +75,17 @@ class OrderControllerTest {
         mockMvc.perform(
             post("/api/orders")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(invalidPayload)
+                .content(invalidCartPayload)
         ).andExpect(status().isBadRequest)
     }
 
     @Test
     fun `createOrder should return 400 when given invalid cart item name`() {
         // Arrange
-        val invalidPayload = """
+        val invalidCartItemNamePayload = """
             {
                 "cart": [
-                    {
-                        "name": "invalidFruit",
-                        "quantity": 2
-                    }
+                    {"name": "", "quantity": 1}
                 ]
             }
         """.trimIndent()
@@ -94,7 +94,7 @@ class OrderControllerTest {
         mockMvc.perform(
             post("/api/orders")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(invalidPayload)
+                .content(invalidCartItemNamePayload)
         ).andExpect(status().isBadRequest)
     }
 
@@ -104,23 +104,28 @@ class OrderControllerTest {
         val validPayload = """
             {
                 "cart": [
-                    {
-                        "name": "apple",
-                        "quantity": 2
-                    }
+                    {"name": "apple", "quantity": 3},
+                    {"name": "orange", "quantity": 4}
                 ]
             }
         """.trimIndent()
 
         val mockInvoice = Invoice(
-            lineItems = listOf(
-                LineItem(name = "apple", quantity = 2, itemCost = "0.60", discount = "0.00", lineCost = "1.20")
+            1,
+            listOf(
+                LineItem("apple", 3, "0.60", "0.00", "1.80"),
+                LineItem("orange", 4, "0.25", "0.00", "1.00")
             ),
-            totalDiscount = "0.00",
-            totalCost = "1.20"
+            "0.00",
+            "2.80"
         )
 
-        every { orderService.generateInvoice(any()) } returns mockInvoice
+        every { orderService.createOrder(any()) } returns Order(
+            id = 1,
+            orderDate = LocalDateTime.of(2022, 2, 2, 2, 2, 2),
+            totalAmount = BigDecimal("2.80"),
+            invoice = mockInvoice
+        )
 
         // Act & Assert
         mockMvc.perform(
@@ -128,5 +133,101 @@ class OrderControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(validPayload)
         ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.orderId").value(1))
+    }
+
+    @Test
+    fun `getOrderById should return 200 when given valid ID`() {
+        // Arrange
+        val orderId = 1L
+        val mockOrder = Order(
+            id = orderId,
+            orderDate = LocalDateTime.of(2022, 2, 2, 2, 2, 2),
+            totalAmount = BigDecimal("2.80"),
+            invoice = Invoice(
+                1,
+                listOf(
+                    LineItem("apple", 3, "0.60", "0.00", "1.80"),
+                    LineItem("orange", 4, "0.25", "0.00", "1.00")
+                ),
+                "0.00",
+                "2.80"
+            )
+        )
+
+        every { orderService.getOrderById(orderId) } returns mockOrder
+
+        // Act & Assert
+        mockMvc.perform(
+            get("/api/orders/{id}", orderId)
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value(orderId))
+    }
+
+    @Test
+    fun `getOrderById should return 400 when given invalid ID`() {
+        // Act & Assert
+        mockMvc.perform(
+            get("/api/orders/{id}", "invalid")
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `getOrderById should return 404 when order not found`() {
+        // Arrange
+        val orderId = 999999999999999999L
+        every { orderService.getOrderById(orderId) } returns null
+
+        // Act & Assert
+        mockMvc.perform(
+            get("/api/orders/{id}", orderId)
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `getAllOrders should return 200 with list of orders`() {
+        // Arrange
+        val mockOrders = listOf(
+            Order(
+                id = 1,
+                orderDate = LocalDateTime.of(2022, 2, 2, 2, 2, 2),
+                totalAmount = BigDecimal("2.80"),
+                invoice = Invoice(
+                    1,
+                    listOf(
+                        LineItem("apple", 3, "0.60", "0.00", "1.80"),
+                        LineItem("orange", 4, "0.25", "0.00", "1.00")
+                    ),
+                    "0.00",
+                    "2.80"
+                )
+            ),
+            Order(
+                id = 2,
+                orderDate = LocalDateTime.of(2022, 2, 3, 2, 2, 2),
+                totalAmount = BigDecimal("3.50"),
+                invoice = Invoice(
+                    2,
+                    listOf(
+                        LineItem("banana", 5, "0.50", "0.00", "2.50"),
+                        LineItem("grape", 2, "0.50", "0.00", "1.00")
+                    ),
+                    "0.00",
+                    "3.50"
+                )
+            )
+        )
+
+        every { orderService.getAllOrders() } returns mockOrders
+
+        // Act & Assert
+        mockMvc.perform(
+            get("/api/orders")
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(mockOrders.size))
     }
 }

--- a/src/test/kotlin/com/testott/fruitstand/model/InvoiceConverterTest.kt
+++ b/src/test/kotlin/com/testott/fruitstand/model/InvoiceConverterTest.kt
@@ -1,0 +1,58 @@
+package com.testott.fruitstand.model
+
+import com.testott.fruitstand.service.Invoice
+import com.testott.fruitstand.service.LineItem
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+
+class InvoiceConverterTest {
+
+    private val objectMapper = jacksonObjectMapper()
+    private val invoiceConverter = InvoiceConverter()
+
+    @Test
+    fun `convertToDatabaseColumn should return correct JSON string`() {
+        // Arrange
+        val invoice = Invoice(
+            orderId = 1,
+            lineItems = listOf(
+                LineItem("apple", 3, "0.60", "0.00", "1.80"),
+                LineItem("orange", 4, "0.25", "0.00", "1.00")
+            ),
+            totalDiscount = "0.00",
+            totalCost = "2.80"
+        )
+
+        // Act
+        val json = invoiceConverter.convertToDatabaseColumn(invoice)
+
+        // Assert
+        val expectedJson = objectMapper.writeValueAsString(invoice)
+        assertEquals(expectedJson, json)
+    }
+
+    @Test
+    fun `convertToEntityAttribute should return correct Invoice`() {
+        // Arrange
+        val json = """
+            {
+                "orderId": 1,
+                "lineItems": [
+                    {"name": "apple", "quantity": 3, "itemCost": "0.60", "discount": "0.00", "lineCost": "1.80"},
+                    {"name": "orange", "quantity": 4, "itemCost": "0.25", "discount": "0.00", "lineCost": "1.00"}
+                ],
+                "totalDiscount": "0.00",
+                "totalCost": "2.80"
+            }
+        """.trimIndent()
+
+        // Act
+        val invoice = invoiceConverter.convertToEntityAttribute(json)
+
+        // Assert
+        val expectedInvoice = objectMapper.readValue<Invoice>(json)
+        assertEquals(expectedInvoice, invoice)
+    }
+}


### PR DESCRIPTION
### Notes
- Orders are now being stored when they come in through the POST API endpoint. The invoice is stored to the order as JSON to create a snapshot of the order at the time of purchase. This could be changed to be an Invoice entity that gets stored to the database in the future.
- I added a custom converter to deal with the JSON stored in the database. I decided to store it as text to make it simple, and the converter parses this.
- Two new API endpoints have been added:
  - `GET /api/orders` - This simply returns all orders that exist in the data store. Very dangerous, but one of the requirements of the assessment.
  - `GET /api/orders/<id>` - This retrieves an order based on its ID and returns it.

### Testing
- `./gradlew test`
- New unit tests have been added, and the OrderController unit tests have been updated to make them a bit better, include the new invoice/order system, as well as include the new API endpoints.

#### Links
- Closes #3